### PR TITLE
Dft fix

### DIFF
--- a/pymodule.py
+++ b/pymodule.py
@@ -133,7 +133,7 @@ def run_polaritonic_scf_gradient(name, **kwargs):
     elif ( lowername == 'polaritonic-uks' ):
         psi4.core.set_local_option('HILBERT', 'HILBERT_METHOD', 'POLARITONIC_UKS')
     elif ( lowername == 'polaritonic-rks' ):
-        psi4.core.set_local_option('HILBERT', 'HILBERT_METHOD', 'POLARITONIC_UKS')
+        psi4.core.set_local_option('HILBERT', 'HILBERT_METHOD', 'POLARITONIC_RKS')
     elif ( lowername == 'polaritonic-rcis' ):
         psi4.core.set_local_option('HILBERT', 'HILBERT_METHOD', 'POLARITONIC_RCIS')
     elif ( lowername == 'polaritonic-uccsd' ):

--- a/src/polaritonic_scf/rtddft.cc
+++ b/src/polaritonic_scf/rtddft.cc
@@ -357,6 +357,35 @@ double PolaritonicRTDDFT::compute_energy() {
     size_t ID = options_.get_int("INDIM");
     size_t maxdim = MD*M;
     size_t init_dim = ID*M;
+    if ( M > N ) {
+        outfile->Printf("    WARNING: NUM_ROOTS > N, NUM_ROOTS = %i, N = %i\n",M,N);
+        outfile->Printf("        setting NUM_ROOTS = N\n");
+        M = N;
+    }
+    if ( init_dim < M ) {
+        outfile->Printf("    WARNING: INDIM < NUM_ROOTS, INDIM = %i, NUM_ROOTS = %i\n",init_dim,M);
+        outfile->Printf("        setting INDIM = NUM_ROOTS\n");
+        init_dim = M;
+    }
+    if ( init_dim > N ) {
+        outfile->Printf("    WARNING: INDIM > N, INDIM = %i, N = %i\n",init_dim,N);
+        outfile->Printf("        setting INDIM = N\n");
+        init_dim = N;
+    }
+    if ( maxdim < init_dim ) { 
+        outfile->Printf("    WARNING: MAXDIM < INDIM, MAXDIM = %i, INDIM = %i\n",maxdim,init_dim);
+        outfile->Printf("        setting MAXDIM = INDIM\n");
+        maxdim = init_dim;
+    }
+    if ( maxdim > N ) {
+        outfile->Printf("    WARNING: MAXDIM > N, MAXDIM = %i, N = %i\n",maxdim,N);
+        outfile->Printf("        setting MAXDIM = N\n");
+        maxdim = N;
+    }
+    outfile->Printf("    No. states:                     %5i\n",N);
+    outfile->Printf("    No. roots:                      %5i\n",M);
+    outfile->Printf("    Max subspace dim:               %5i\n",maxdim);
+    outfile->Printf("    Initial subspace dim:           %5i\n",init_dim);
 
     // (approximate) diagonal of Hamiltonian
     double * Hdiag = build_hamiltonian_diagonals();

--- a/src/polaritonic_scf/utddft.cc
+++ b/src/polaritonic_scf/utddft.cc
@@ -508,8 +508,38 @@ double PolaritonicUTDDFT::compute_energy() {
     // number of desired roots
     int M = options_.get_int("NUM_ROOTS");
 
-    // maximum subspace size
-    int maxdim = 8 * M;
+    // subspace multipliers
+    size_t MD = options_.get_int("MAXDIM");
+    size_t ID = options_.get_int("INDIM");
+
+    // set maximum and initial subspace dimensions
+    size_t maxdim = MD*M;
+    size_t init_dim = ID*M;
+    if ( M > N ) {
+        outfile->Printf("    WARNING: NUM_ROOTS > N, NUM_ROOTS = %i, N = %i\n",M,N);
+        outfile->Printf("        setting NUM_ROOTS = N\n");
+        M = N;
+    }
+    if ( init_dim < M ) {
+        outfile->Printf("    WARNING: INDIM < NUM_ROOTS, INDIM = %i, NUM_ROOTS = %i\n",init_dim,M);
+        outfile->Printf("        setting INDIM = NUM_ROOTS\n");
+        init_dim = M;
+    }
+    if ( init_dim > N ) {
+        outfile->Printf("    WARNING: INDIM > N, INDIM = %i, N = %i\n",init_dim,N);
+        outfile->Printf("        setting INDIM = N\n");
+        init_dim = N;
+    }
+    if ( maxdim < init_dim ) { 
+        outfile->Printf("    WARNING: MAXDIM < INDIM, MAXDIM = %i, INDIM = %i\n",maxdim,init_dim);
+        outfile->Printf("        setting MAXDIM = INDIM\n");
+        maxdim = init_dim;
+    }
+    if ( maxdim > N ) {
+        outfile->Printf("    WARNING: MAXDIM > N, MAXDIM = %i, N = %i\n",maxdim,N);
+        outfile->Printf("        setting MAXDIM = N\n");
+        maxdim = N;
+    }
 
     // (approximate) diagonal of Hamiltonian
     double * Hdiag = build_hamiltonian_diagonals();
@@ -522,7 +552,6 @@ double PolaritonicUTDDFT::compute_energy() {
     double ** rerp = rer->pointer();
     double ** relp = rel->pointer();
 
-    int init_dim = 4 * M;
     bool use_residual_norm = true;
     double residual_norm = 1e-5;
 

--- a/tests/polaritonic_scf/tddft.in
+++ b/tests/polaritonic_scf/tddft.in
@@ -38,6 +38,8 @@ set hilbert {
   n_photon_states          2
   cavity_frequency         [0.0, 0.0, $w]
   cavity_coupling_strength [0.0, 0.0, $g]
+  maxdim                   15
+  indim                    5
 }
 
 activate(h2)


### PR DESCRIPTION
In run_polaritonic_gradient, polaritonic-rks would call polaritonic-uks.
It now calls polaritonic-rks.

No input checking for maxdim and indim within polaritonic-tddft.
The user was allowed to allocate a larger subspace than the number of states and less than the number of roots.
We have added error checking that prints a warning and reassigns the variables.