### PR TITLE
Psi4 v1.10

### DIFF
--- a/external/liblbfgs/CMakeLists.txt
+++ b/external/liblbfgs/CMakeLists.txt
@@ -5,8 +5,8 @@ include(FetchContent)
 
 message(STATUS "liblbfgs will be built at compile time")
 FetchContent_Declare(liblbfgs_external
-    GIT_REPOSITORY https://github.com/chokkan/liblbfgs.git
-
+    #GIT_REPOSITORY https://github.com/chokkan/liblbfgs.git
+    GIT_REPOSITORY https://github.com/edeprince3/liblbfgs.git
 )
 FetchContent_MakeAvailable(liblbfgs_external)
 

--- a/pymodule.py
+++ b/pymodule.py
@@ -984,8 +984,8 @@ def run_mcpdft(name, **kwargs):
     inp = {
         "rho" : combined_rho,
         "sigma" : sigma,
-        "lapl" : None,
-        "tau" : None
+        #"lapl" : None,
+        #"tau" : None
     }
 
     ex = 0.0

--- a/src/doci/doci_solver.cc
+++ b/src/doci/doci_solver.cc
@@ -102,12 +102,12 @@ void  DOCISolver::common_init(){
 
     is_df_ = false;
 
-    if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD" ) {
+    if ( options_.get_str("SCF_TYPE") == "DISK_DF" || options_.get_str("SCF_TYPE") == "DISK_CD") {
         is_df_ = true;
     }
 
     if ( !is_df_ ) {
-        throw PsiException("plugin doci only works with scf_type = df or cd, for now",__FILE__,__LINE__);
+        throw PsiException("plugin doci only works with scf_type = disk_df or disk_cd, for now",__FILE__,__LINE__);
     }
 
     shallow_copy(reference_wavefunction_);

--- a/src/focas/orbital_optimizer.cc
+++ b/src/focas/orbital_optimizer.cc
@@ -61,15 +61,17 @@ OrbitalOptimizer::OrbitalOptimizer(std::shared_ptr<Wavefunction> reference_wavef
     frzvpi_ = reference_wavefunction->frzvpi();
     nmopi_  = reference_wavefunction->nmopi();
 
-    if ( reference_wavefunction->options().get_str("SCF_TYPE") == "DF" ) {
+    if ( reference_wavefunction->options().get_str("SCF_TYPE") == "DISK_DF" ) {
         std::shared_ptr<BasisSet> primary = reference_wavefunction->basisset();
         std::shared_ptr<BasisSet> auxiliary = reference_wavefunction->get_basisset("DF_BASIS_SCF");
         nQ_ = auxiliary->nbf();
-    }else if ( reference_wavefunction->options().get_str("SCF_TYPE") == "CD" ) {
+    }else if ( reference_wavefunction->options().get_str("SCF_TYPE") == "DISK_CD" ) {
         std::shared_ptr<PSIO> psio(new PSIO());
         psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
         psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ_, sizeof(long int));
         psio->close(PSIF_DFSCF_BJ,1);
+    }else if ( reference_wavefunction->options().get_str("SCF_TYPE") == "DF" || reference_wavefunction->options().get_str("SCF_TYPE") == "CD") {
+        throw PsiException("invalid SCF_TYPE. try DISK_DF, DISK_CD, or PK",__FILE__,__LINE__);
     }
 
     // restricted doubly occupied orbitals per irrep (optimized)

--- a/src/misc/threeindexintegrals.cc
+++ b/src/misc/threeindexintegrals.cc
@@ -61,16 +61,18 @@ void ThreeIndexIntegrals(std::shared_ptr<Wavefunction> ref, long int &nQ, long i
     // read integrals that were written to disk in the scf
     std::shared_ptr<PSIO> psio(new PSIO());
 
-    if ( ref->options().get_str("SCF_TYPE") == "DF" ) {
+    if ( ref->options().get_str("SCF_TYPE") == "DISK_DF" ) {
         std::shared_ptr<BasisSet> primary = ref->basisset(); 
         std::shared_ptr<BasisSet> auxiliary = ref->get_basisset("DF_BASIS_SCF");
 
         nQ = auxiliary->nbf();
         Process::environment.globals["NAUX (SCF)"] = nQ;
-    }else if ( ref->options().get_str("SCF_TYPE") == "CD" ) {
+    }else if ( ref->options().get_str("SCF_TYPE") == "DISK_CD" ) {
         psio->open(PSIF_DFSCF_BJ,PSIO_OPEN_OLD);
         psio->read_entry(PSIF_DFSCF_BJ, "length", (char*)&nQ, sizeof(long int));
         psio->close(PSIF_DFSCF_BJ,1);
+    }else {
+        throw PsiException("invalid SCF_TYPE. try DISK_DF or DISK_CD",__FILE__,__LINE__);
     }
 
     // 100 mb extra to account for all mapping arrays already 

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -138,18 +138,6 @@ int read_options(std::string name, Options& options)
 
         /*- SUBSECTION ORBITAL OPTIMIZATION -*/
 
-        options.add_bool("MOLDEN_WRITE", false);
-        /*- Do write a MOLDEN file for guess orbitals?  If so, the filename will
-        end in .guess.molden, and the prefix is determined by 
-        |globals__writer_file_label| (if set), or else by the name of the output
-        file plus the name of the current molecule. -*/
-
-        options.add_bool("GUESS_ORBITALS_WRITE", false);
-        /*- Do write a ORBOPT output file?  If so, the filename will end in
-        .molden, and the prefix is determined by |globals__writer_file_label|
-        (if set), or else by the name of the output file plus the name of
-        the current molecule. -*/
-
         /*- flag to optimize orbitals using a one-step type approach -*/
         options.add_bool("ORBOPT_ONE_STEP",true);
 

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -114,7 +114,7 @@ int read_options(std::string name, Options& options)
         /*- What algorithm to use for the SCF computation. See Table :ref:`SCF
         Convergence & Algorithm <table:conv_scf>` for default algorithm for
         different calculation types. -*/
-        options.add_str("SCF_TYPE", "DF", "DF CD");
+        options.add_str("SCF_TYPE", "DISK_DF", "DISK_DF DISK_CD PK");
 
         /*- SUBSECTION DOCI -*/
 
@@ -396,15 +396,8 @@ int read_options(std::string name, Options& options)
 
         /*- SUBSECTION MCPDFT -*/
 
-       /*- MCPDFT type -*/
-        options.add_str("MCPDFT_METHOD", "MCPDFT", "MCPDFT");
         /*- MCPDFT functional -*/
         options.add_str("MCPDFT_FUNCTIONAL", "PBE");
-        /*- JK object type can be DF or PK -*/
-        options.add_str("MCPDFT_TYPE", "DF", "DF PK");
-        /*- reference type -*/
-        options.add_str("MCPDFT_REFERENCE", "V2RDM");
-
 
         /*- SUBSECTION CC_Cavity -*/
 
@@ -468,7 +461,6 @@ int read_options(std::string name, Options& options)
 
         /*- boolean for whether to compute the 2-RDM -*/
         options.add_bool("COMPUTE_2RDM", false);
-
     }
 
     return true;

--- a/src/pp2rdm/pp2rdm_solver.cc
+++ b/src/pp2rdm/pp2rdm_solver.cc
@@ -91,12 +91,12 @@ void  pp2RDMSolver::common_init(){
 
     is_df_ = false;
 
-    if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD" ) {
+    if ( options_.get_str("SCF_TYPE") == "DISK_DF" || options_.get_str("SCF_TYPE") == "DISK_CD") {
         is_df_ = true;
     }
 
     if ( !is_df_ ) {
-        throw PsiException("plugin pp2rdm only works with scf_type = df or cd, for now",__FILE__,__LINE__);
+        throw PsiException("plugin pp2rdm only works with scf_type = disk_df or disk_cd, for now",__FILE__,__LINE__);
     }
 
     shallow_copy(reference_wavefunction_);

--- a/src/v2rdm_casscf/v2rdm_solver.cc
+++ b/src/v2rdm_casscf/v2rdm_solver.cc
@@ -29,7 +29,6 @@
 #include <math.h>
 
 #include <psi4/libmints/mintshelper.h>
-#include <psi4/libmints/writer.h>
 #include <psi4/libmints/writer_file_prefix.h>
 #include <psi4/libtrans/integraltransform.h>
 #include <psi4/libtrans/mospace.h>
@@ -1274,31 +1273,6 @@ double v2RDMSolver::compute_energy() {
     double start_total_time = omp_get_wtime();
 
     // print guess orbitals in molden format
-    if ( options_.get_bool("GUESS_ORBITALS_WRITE") && !is_hubbard_ && !is_external_hamiltonian_) {
-
-        std::shared_ptr<MoldenWriter> molden(new MoldenWriter(reference_wavefunction_));
-        std::shared_ptr<Vector> zero = std::make_shared<Vector>(nmopi_);
-        zero->zero();
-        std::string filename = get_writer_file_prefix(reference_wavefunction_->molecule()->name()) + ".guess.molden";
-
-        Ca_ = SharedMatrix(reference_wavefunction_->Ca());
-        Cb_ = SharedMatrix(reference_wavefunction_->Cb());
-
-        SharedVector occupation_a = std::make_shared<Vector>(nmopi_);
-        SharedVector occupation_b = std::make_shared<Vector>(nmopi_);
-
-        for (int h = 0; h < nirrep_; h++) {
-            for (int i = 0; i < nalphapi_[h]; i++) {
-                occupation_a->set(h, i, 1.0);
-            }
-            for (int i = 0; i < nbetapi_[h]; i++) {
-                occupation_b->set(h, i, 1.0);
-            }
-        }
-
-        molden->write(filename, Ca_, Cb_, zero, zero, occupation_a, occupation_b, true);
-    }
-
     // hartree-fock guess
     Guess();
 
@@ -1477,9 +1451,6 @@ double v2RDMSolver::compute_energy() {
             ComputeNaturalOrbitals();
         }  
 
-    }
-    if ( options_.get_bool("MOLDEN_WRITE") && !is_hubbard_ && !is_external_hamiltonian_ ) {
-        WriteMoldenFile();
     }
     if ( options_.get_bool("EXTENDED_KOOPMANS") && !is_hubbard_ && !is_external_hamiltonian_ ) {
         ExtendedKoopmans();
@@ -1663,89 +1634,6 @@ void v2RDMSolver::EnergyByComponent(double &kinetic, double &potential, double &
     }
 }
 
-
-void v2RDMSolver::WriteMoldenFile() {
-
-    // it is possible the 1-RDM is already in the NO basis:
-    if ( options_.get_bool("NAT_ORBS") || options_.get_bool("FCIDUMP") || options_.get_bool("EXTENDED_KOOPMANS") ) {
-
-        std::shared_ptr<Vector> eigval = std::make_shared<Vector>("Natural Orbital Occupation Numbers (spin free)",nmopi_);
-        for (int h = 0; h < nirrep_; h++) {
-            for (int i = 0; i < frzcpi_[h] + rstcpi_[h]; i++) {
-                eigval->pointer(h)[i] = 1.0;
-            }
-            for (int i = rstcpi_[h] + frzcpi_[h]; i < nmopi_[h] - rstvpi_[h] - frzvpi_[h]; i++) {
-                eigval->pointer(h)[i]  = 0.5 * x->pointer()[d1aoff[h]+(i-rstcpi_[h]-frzcpi_[h])*amopi_[h]+(i-rstcpi_[h]-frzcpi_[h])];
-                eigval->pointer(h)[i] += 0.5 * x->pointer()[d1aoff[h]+(i-rstcpi_[h]-frzcpi_[h])*amopi_[h]+(i-rstcpi_[h]-frzcpi_[h])];
-            }
-        }
-        // Print a molden file
-        if ( options_["RESTART_FROM_CHECKPOINT_FILE"].has_changed() ) {
-            throw PsiException("printing orbitals is currently disabled when restarting v2rdm jobs.  i can't remember why, though... sorry!",__FILE__,__LINE__);
-        }
-        //std::shared_ptr<MoldenWriter> molden(new MoldenWriter((std::shared_ptr<Wavefunction>)this));
-        std::shared_ptr<MoldenWriter> molden(new MoldenWriter(reference_wavefunction_));
-        std::shared_ptr<Vector> zero = std::make_shared<Vector>(nmopi_);
-        zero->zero();
-        std::string filename = get_writer_file_prefix(reference_wavefunction_->molecule()->name()) + ".molden";
-        molden->write(filename,Ca_,Ca_,zero, zero,eigval,eigval,true);
-
-    // otherwise, we need to compute the natural orbitals:
-    }else {
-        std::shared_ptr<Matrix> D (new Matrix(nirrep_,nmopi_,nmopi_));
-        std::shared_ptr<Matrix> eigvec (new Matrix(nirrep_,nmopi_,nmopi_));
-        std::shared_ptr<Vector> eigval = std::make_shared<Vector>("Natural Orbital Occupation Numbers (spin free)",nmopi_);
-        for (int h = 0; h < nirrep_; h++) {
-            for (int i = 0; i < frzcpi_[h] + rstcpi_[h]; i++) {
-                D->pointer(h)[i][i] = 1.0;
-            }
-            for (int i = rstcpi_[h] + frzcpi_[h]; i < nmopi_[h] - rstvpi_[h] - frzvpi_[h]; i++) {
-                for (int j = rstcpi_[h] + frzcpi_[h]; j < nmopi_[h]-rstvpi_[h]-frzvpi_[h]; j++) {
-                    D->pointer(h)[i][j]  = 0.5 * x->pointer()[d1aoff[h]+(i-rstcpi_[h]-frzcpi_[h])*amopi_[h]+(j-rstcpi_[h]-frzcpi_[h])];
-                    D->pointer(h)[i][j] += 0.5 * x->pointer()[d1boff[h]+(i-rstcpi_[h]-frzcpi_[h])*amopi_[h]+(j-rstcpi_[h]-frzcpi_[h])];
-                }
-            }
-        }
-        std::shared_ptr<Matrix> saved ( new Matrix(D) );
-        D->diagonalize(eigvec,eigval,descending);
-        //eigval->print();
-
-        std::shared_ptr<Matrix> Cno (new Matrix(Ca_));
-
-        //Ca_->print();
-        // build AO/NO transformation matrix 
-        for (int h = 0; h < nirrep_; h++) {
-            for (int mu = 0; mu < nsopi_[h]; mu++) {
-                double *  temp = (double*)malloc(nmopi_[h]*sizeof(double));
-                double ** cp   = Cno->pointer(h);
-                double ** ep   = eigvec->pointer(h);
-                for (int i = 0; i < nmopi_[h]; i++) {
-                    double dum = 0.0;
-                    for (int j = 0; j < nmopi_[h]; j++) {
-                        dum += cp[mu][j] * ep[j][i];
-                    }
-                    temp[i] = dum;
-                }
-                for (int i = 0; i < nmopi_[h]; i++) {
-                    cp[mu][i] = temp[i];
-                }
-                free(temp);
-            }
-        }
-
-        // Print a molden file
-        if ( options_["RESTART_FROM_CHECKPOINT_FILE"].has_changed() ) {
-            throw PsiException("printing orbitals is currently disabled when restarting v2rdm jobs.  i can't remember why, though... sorry!",__FILE__,__LINE__);
-        }
-        //std::shared_ptr<MoldenWriter> molden(new MoldenWriter((std::shared_ptr<Wavefunction>)this));
-        std::shared_ptr<MoldenWriter> molden(new MoldenWriter(reference_wavefunction_));
-        std::shared_ptr<Vector> zero = std::make_shared<Vector>(nmopi_);
-        zero->zero();
-        std::string filename = get_writer_file_prefix(reference_wavefunction_->molecule()->name()) + ".molden";
-        molden->write(filename,Cno,Cno,zero, zero,eigval,eigval,true);
-    }
-
-}
 
 void v2RDMSolver::FinalizeOPDM() {
     // nee

--- a/src/v2rdm_casscf/v2rdm_solver.cc
+++ b/src/v2rdm_casscf/v2rdm_solver.cc
@@ -322,8 +322,10 @@ void  v2RDMSolver::common_init(){
     outfile->Printf("\n");
 
     is_df_ = false;
-    if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD" ) {
+    if ( options_.get_str("SCF_TYPE") == "DISK_DF" || options_.get_str("SCF_TYPE") == "DISK_CD") {
         is_df_ = true;
+    }else if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD") {
+        throw PsiException("invalid SCF_TYPE. try DISK_DF, DISK_CD, or PK",__FILE__,__LINE__);
     }
 
     // initialization depends on hamiltonian type

--- a/src/v2rdm_casscf/v2rdm_solver.h
+++ b/src/v2rdm_casscf/v2rdm_solver.h
@@ -633,9 +633,6 @@ class v2RDMSolver: public Wavefunction{
     /// write active 3RDM to disk
     void WriteActive3PDM();
 
-    /// write molden file
-    void WriteMoldenFile();
-
     /// read 3RDM from disk
     void Read3PDM();
 

--- a/src/v2rdm_doci/v2rdm_doci_solver.cc
+++ b/src/v2rdm_doci/v2rdm_doci_solver.cc
@@ -1159,10 +1159,6 @@ double v2RDM_DOCISolver::compute_energy() {
         UpdateTransformationMatrix(reference_wavefunction_,newMO_,Ca_,Cb_,orbopt_transformation_matrix_);
     }
 
-    if ( options_.get_bool("MOLDEN_WRITE") ) {
-        WriteMoldenFile();
-    }
-
     if ( options_.get_bool("SEMICANONICALIZE_ORBITALS") ) {
         if ( options_.get_str("DERTYPE") == "FIRST" ) {
             outfile->Printf("\n");
@@ -1223,65 +1219,6 @@ double v2RDM_DOCISolver::compute_energy() {
     outfile->Printf("\n");
 
     return energy_primal + enuc_ + efzc_;
-}
-
-void v2RDM_DOCISolver::WriteMoldenFile() {
-
-    throw PsiException("function WriteMoldenFile() is currently broken",__FILE__,__LINE__);
-
-/*
-    std::shared_ptr<Matrix> D (new Matrix(nirrep_,nmopi_,nmopi_));
-    std::shared_ptr<Matrix> eigvec (new Matrix(nirrep_,nmopi_,nmopi_));
-    std::shared_ptr<Vector> eigval (new Vector("Natural Orbital Occupation Numbers (spin free)",nirrep_,nmopi_));
-    for (int h = 0; h < nirrep_; h++) {
-        for (int i = 0; i < frzcpi_[h] + rstcpi_[h]; i++) {
-            D->pointer(h)[i][i] = 2.0;
-        }
-        for (int i = rstcpi_[h] + frzcpi_[h]; i < nmopi_[h] - rstvpi_[h] - frzvpi_[h]; i++) {
-            for (int j = rstcpi_[h] + frzcpi_[h]; j < nmopi_[h]-rstvpi_[h]-frzvpi_[h]; j++) {
-                D->pointer(h)[i][j]  = 2.0 * x->pointer()[d1off[h]+(i-rstcpi_[h]-frzcpi_[h])*amopi_[h]+(j-rstcpi_[h]-frzcpi_[h])];
-            }
-        }
-    }
-    std::shared_ptr<Matrix> saved ( new Matrix(D) );
-    D->diagonalize(eigvec,eigval,descending);
-    eigval->print();
-
-    std::shared_ptr<Matrix> Cno (new Matrix(Ca_));
-
-    //Ca_->print();
-    // build AO/NO transformation matrix 
-    for (int h = 0; h < nirrep_; h++) {
-        for (int mu = 0; mu < nsopi_[h]; mu++) {
-            double *  temp = (double*)malloc(nmopi_[h]*sizeof(double));
-            double ** cp   = Cno->pointer(h);
-            double ** ep   = eigvec->pointer(h);
-            for (int i = 0; i < nmopi_[h]; i++) {
-                double dum = 0.0;
-                for (int j = 0; j < nmopi_[h]; j++) {
-                    dum += cp[mu][j] * ep[j][i];
-                }
-                temp[i] = dum;
-            }
-            for (int i = 0; i < nmopi_[h]; i++) {
-                cp[mu][i] = temp[i];
-            }
-            free(temp);
-        }
-    }
-
-    // Print a molden file
-    if ( options_["RESTART_FROM_CHECKPOINT_FILE"].has_changed() ) {
-        throw PsiException("printing orbitals is currently disabled when restarting v2rdm jobs.  sorry!",__FILE__,__LINE__);
-    }
-    //std::shared_ptr<MoldenWriter> molden(new MoldenWriter((std::shared_ptr<Wavefunction>)this));
-    std::shared_ptr<MoldenWriter> molden(new MoldenWriter(reference_wavefunction_));
-    std::shared_ptr<Vector> zero (new Vector("",nirrep_,nmopi_));
-    zero->zero();
-    std::string filename = get_writer_file_prefix(reference_wavefunction_->molecule()->name()) + ".molden";
-    molden->write(filename,Cno,Cno,zero, zero,eigval,eigval,true);
-*/
-
 }
 
 void v2RDM_DOCISolver::NaturalOrbitals() {

--- a/src/v2rdm_doci/v2rdm_doci_solver.cc
+++ b/src/v2rdm_doci/v2rdm_doci_solver.cc
@@ -129,8 +129,11 @@ v2RDM_DOCISolver::~v2RDM_DOCISolver()
 void  v2RDM_DOCISolver::common_init(){
 
     is_df_ = false;
-    if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD" ) {
+
+    if ( options_.get_str("SCF_TYPE") == "DISK_DF" || options_.get_str("SCF_TYPE") == "DISK_CD") {
         is_df_ = true;
+    }else if ( options_.get_str("SCF_TYPE") == "DF" || options_.get_str("SCF_TYPE") == "CD") {
+        throw PsiException("invalid SCF_TYPE. try DISK_DF, DISK_CD, or PK",__FILE__,__LINE__);
     }
 
     shallow_copy(reference_wavefunction_);

--- a/src/v2rdm_doci/v2rdm_doci_solver.h
+++ b/src/v2rdm_doci/v2rdm_doci_solver.h
@@ -310,9 +310,6 @@ class v2RDM_DOCISolver: public Wavefunction{
     /// read 2RDM from disk
     void ReadTPDM();
 
-    /// write molden file
-    void WriteMoldenFile();
-
     /// orbital lagrangian
     double * X_;
 

--- a/tests/doci/input.dat
+++ b/tests/doci/input.dat
@@ -16,7 +16,8 @@ symmetry c1
 set {
   reference rhf
   basis 6-31g
-  scf_type df
+  scf_type disk_df
+  df_ints_io save
 
   e_convergence 1e-10
   r_convergence 1e-8

--- a/tests/mcpdft/input.dat
+++ b/tests/mcpdft/input.dat
@@ -13,7 +13,7 @@ n 1 1.1
 
 set {
   basis cc-pvdz
-  scf_type df
+  scf_type disk_df
   d_convergence      1e-10
   maxiter 500
   restricted_docc [ 2, 0, 0, 0, 0, 2, 0, 0 ]
@@ -34,10 +34,7 @@ set hilbert {
   optimize_orbitals true
   mu_update_frequency 500
 
-  mcpdft_reference v2rdm
-  mcpdft_type df
   mcpdft_functional blyp
-  mcpdft_method mcpdft
 }
 
 # run v2rdm-casscf

--- a/tests/pccd/input.dat
+++ b/tests/pccd/input.dat
@@ -16,7 +16,7 @@ symmetry c1
 set {
   reference rhf
   basis 6-31g
-  scf_type df
+  scf_type disk_df
 
   e_convergence 1e-10
   r_convergence 1e-8

--- a/tests/pp2rdm/input.dat
+++ b/tests/pp2rdm/input.dat
@@ -17,7 +17,7 @@ set {
 
   reference rhf
   basis 6-31g
-  scf_type df
+  scf_type disk_df
 
   e_convergence 1e-10
   r_convergence 1e-8

--- a/tests/v2rdm2/input.dat
+++ b/tests/v2rdm2/input.dat
@@ -14,7 +14,7 @@ n 1 r
 
 set {
   basis cc-pvdz
-  scf_type df
+  scf_type disk_df
   d_convergence      1e-10
   maxiter 500
   restricted_docc [ 2, 0, 0, 0, 0, 2, 0, 0 ]

--- a/tests/v2rdm4/input.dat
+++ b/tests/v2rdm4/input.dat
@@ -36,7 +36,7 @@ N      0.00000000    -2.71003942     0.00000000
 set {
   ints_tolerance 0.0
   basis cc-pvdz
-  scf_type df
+  scf_type disk_df
   d_convergence 1e-8
   maxiter 500
   reference rohf

--- a/tests/v2rdm_doci/input.dat
+++ b/tests/v2rdm_doci/input.dat
@@ -16,7 +16,7 @@ symmetry c1
 set {
   reference rhf
   basis 6-31g
-  scf_type df
+  scf_type disk_df
 
   e_convergence 1e-4
   r_convergence 1e-5


### PR DESCRIPTION
This PR makes hilbert compatible with psi4 v1.10. 

- removes MoldenWriter
- changes scf_type to disk_df / disk_cd because psi4 seemingly won't write the integrals for scf_type df
- updates liblbfgs version to be my forked version that uses newer cmake